### PR TITLE
changes for large file support on 32 bit systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,10 @@ so your version of libtar will not be thread-safe.
 fi
 
 
+dnl ### Eable large file support. ##################################
+AC_SYS_LARGEFILE
+
+
 dnl ### Checks for header files. ###################################
 AC_HEADER_STDC
 AC_CHECK_HEADERS([unistd.h])

--- a/lib/libtar.h
+++ b/lib/libtar.h
@@ -282,12 +282,12 @@ int th_signed_crc_calc(TAR *t);
 #define th_crc_ok(t) (th_get_crc(t) == th_crc_calc(t) || th_get_crc(t) == th_signed_crc_calc(t))
 
 /* string-octal to integer conversion */
-int oct_to_int(char *oct);
-off_t oct_to_size(char *oct);
+#define oct_to_int(value) oct_to_int_bounds(value, sizeof(value), 0, ~0 ^ (int)1<<sizeof(int)*8-1)
+#define oct_to_size(value) oct_to_int_bounds(value, sizeof(value), 0, ~0 ^ (off_t)1<<sizeof(off_t)*8-1)
+off_t oct_to_int_bounds(char *oct, int len, off_t min, off_t max);
 
 /* integer to NULL-terminated string-octal conversion */
-#define int_to_oct(num, oct, octlen) \
-	snprintf((oct), (octlen), "%*llo ", (octlen) - 2, (unsigned long long)(num))
+void int_to_oct(off_t num, char * oct, int octlen);
 
 /* integer to string-octal conversion, no NULL */
 void int_to_oct_nonull(off_t num, char *oct, size_t octlen);

--- a/lib/libtar.h
+++ b/lib/libtar.h
@@ -16,8 +16,13 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <tar.h>
+#include <unistd.h>
 
 #include <libtar_listhash.h>
+
+#if (defined(_POSIX_V6_ILP32_OFF32) || defined(_POSIX_V7_ILP32_OFF32)) && _FILE_OFFSET_BITS != 64
+    #warning _FILE_OFFSET_BITS is not set to 64. libtar may demonstrate errors.
+#endif
 
 #ifdef __cplusplus
 extern "C"
@@ -278,14 +283,14 @@ int th_signed_crc_calc(TAR *t);
 
 /* string-octal to integer conversion */
 int oct_to_int(char *oct);
-size_t oct_to_size(char *oct);
+off_t oct_to_size(char *oct);
 
 /* integer to NULL-terminated string-octal conversion */
 #define int_to_oct(num, oct, octlen) \
-	snprintf((oct), (octlen), "%*lo ", (octlen) - 2, (unsigned long)(num))
+	snprintf((oct), (octlen), "%*llo ", (octlen) - 2, (unsigned long long)(num))
 
 /* integer to string-octal conversion, no NULL */
-void int_to_oct_nonull(int num, char *oct, size_t octlen);
+void int_to_oct_nonull(off_t num, char *oct, size_t octlen);
 
 
 /***** wrapper.c **********************************************************/

--- a/lib/output.c
+++ b/lib/output.c
@@ -102,7 +102,7 @@ th_print_long_ls(TAR *t)
 	if (TH_ISCHR(t) || TH_ISBLK(t))
 		printf(" %3d, %3d ", th_get_devmajor(t), th_get_devminor(t));
 	else
-		printf("%9ld ", (long)th_get_size(t));
+		printf("%9llu ", (unsigned long long)th_get_size(t));
 
 	mtime = th_get_mtime(t);
 	mtm = localtime(&mtime);

--- a/lib/util.c
+++ b/lib/util.c
@@ -151,21 +151,21 @@ oct_to_int(char *oct)
 	return sscanf(oct, "%o", &i) == 1 ? i : 0;
 }
 
-/* string-octal to size_t conversion */
-size_t
+/* string-octal to filesize conversion */
+off_t
 oct_to_size(char *oct)
 {
-	size_t i;
+	unsigned long long i;
 
-	return sscanf(oct, "%zo", &i) == 1 ? i : 0;
+	return sscanf(oct, "%llo", &i) == 1 ? i : 0;
 }
 
 
 /* integer to string-octal conversion, no NULL */
 void
-int_to_oct_nonull(int num, char *oct, size_t octlen)
+int_to_oct_nonull(off_t num, char *oct, size_t octlen)
 {
-	snprintf(oct, octlen, "%*lo", (int)(octlen - 1), (unsigned long)num);
+	snprintf(oct, octlen, "%*llo", (int)(octlen - 1), (unsigned long long)num);
 	oct[octlen - 1] = ' ';
 }
 

--- a/lib/util.c
+++ b/lib/util.c
@@ -143,21 +143,35 @@ th_signed_crc_calc(TAR *t)
 
 
 /* string-octal to integer conversion */
-int
-oct_to_int(char *oct)
+off_t
+oct_to_int_bounds(char *oct, int len, off_t min, off_t max)
 {
-	int i;
+	long long i;
+	if (oct[0] & 0x80) {
+		// common base 256 extension
 
-	return sscanf(oct, "%o", &i) == 1 ? i : 0;
+		// sign-extend
+		i = (oct[0] & 0x40) ? (off_t)-1 << ((len - 1) * 8) : 0;
+		// remove sign from first byte
+		i |= (off_t)(oct[0] & 0x7f) << ((len - 1) * 8);
+		// base 256
+		for (int w = 1; w < len; w ++) {
+			i |= (off_t)oct[w] << ((len - 1 - w) * 8);
+		}
+	} else {
+		if (sscanf(oct, "%llo", &i) == 0) {
+			i = 0;
+		}
+	}
+	return (i >= min && i <= max) ? i : 0;
 }
 
-/* string-octal to filesize conversion */
-off_t
-oct_to_size(char *oct)
+/* integer to NULL-terminated string-octal conversion */
+void
+int_to_oct(off_t num, char * oct, int octlen)
 {
-	unsigned long long i;
-
-	return sscanf(oct, "%llo", &i) == 1 ? i : 0;
+	int_to_oct_nonull(num, oct, octlen - 1);
+	oct[octlen - 1] = '\0';
 }
 
 
@@ -165,8 +179,18 @@ oct_to_size(char *oct)
 void
 int_to_oct_nonull(off_t num, char *oct, size_t octlen)
 {
-	snprintf(oct, octlen, "%*llo", (int)(octlen - 1), (unsigned long long)num);
-	oct[octlen - 1] = ' ';
+	if (num >= 0 && num <= 077777777777) {
+		snprintf(oct, octlen, "%*llo", (int)(octlen - 1), (unsigned long long)num);
+		oct[octlen - 1] = ' ';
+	} else {
+		// common base 256 extension
+		while (octlen) {
+			octlen --;
+			oct[octlen] = num & 0xff;
+			num >>= 8;
+		}
+		oct[0] |= 0x80;
+	}
 }
 
 


### PR DESCRIPTION
fixes #3

I've tested this only with https://github.com/xloem/streamtar, which doesn't use the whole api.  streamtar is working fine on 32-bit and 64-bit platforms with this change, when _FILE_OFFSET_BITS=64 is set.

Explanation:
When large file support is enabled, autoconf sets the _FILE_OFFSET_BITS=64 preprocessor define.  Posix-conforming systems will then make off_t 64 bits instead of 32 bits, and reference 64 bit file access functions instead of 32 bit file access functions.  This mostly matters for the `stat` struct, which is in both the header file and the source file, where the define could differ.  The posix defines I check at the top of the header file are set if the size of off_t and other values is 32 bits.  This will result in corruption of large file sizes in tars, so a compile-time warning is emitted.  The warning will show up if libtar is configured to disable large file support, or if libtar is used with large file support disabled.